### PR TITLE
Fixed permissions and version naming in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     
@@ -44,5 +46,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         name: Release ${{ env.VERSION }}
-        tag_name: v${{ env.VERSION }}
+        tag_name: ${{ env.VERSION }}
         generate_release_notes: true


### PR DESCRIPTION
Forgot to set permissions, and version tag had an extra "v".